### PR TITLE
Refactor bits of OCC, utilizing better asfpy methods

### DIFF
--- a/occ.py
+++ b/occ.py
@@ -138,7 +138,7 @@ async def parse_commit(payload, config):
                         blamelist = subdata.get('blamelist')
                         blamesubject = subdata.get('blamesubject', "OCC execution failure")
                         try:
-                            run_as(runas, cmd_args)
+                            await run_as(runas, cmd_args)
                             print("Command executed successfully")
                         except CommandException as e:
                             print("on-commit command failed with exit code %d!" % e.exitcode)

--- a/occ.py
+++ b/occ.py
@@ -19,9 +19,9 @@
 import asfpy.messaging
 import asfpy.pubsub
 import asfpy.syslog
+import asfpy.whoami
 import yaml
 import subprocess
-import socket
 import pwd
 import os
 import getpass
@@ -30,7 +30,7 @@ import sys
 
 print = asfpy.syslog.Printer(stdout=True, identity="occ")
 
-ME = socket.gethostname()
+ME = asfpy.whoami.whoami()
 TMPL_FAILURE = ME + """ failed to reconfigure due to the following error(s):
 
 Return code: %d

--- a/occ.py
+++ b/occ.py
@@ -25,6 +25,8 @@ import socket
 import pwd
 import os
 import getpass
+import asyncio
+import sys
 
 print = asfpy.syslog.Printer(stdout=True, identity="occ")
 
@@ -47,7 +49,7 @@ class CommandException(Exception):
         self.exitcode = exitcode
 
 
-def run_as(username=getpass.getuser(), args=()):
+async def run_as(username=getpass.getuser(), args=()):
     """ Run a command as a specific user """
     if not args:
         return   # Nothing to do? boooo
@@ -97,7 +99,7 @@ def change_user(user_uid, user_gid):
     return result
 
 
-def parse_commit(payload, config):
+async def parse_commit(payload, config):
     if 'stillalive' in payload:  # Ping, Pong...
         return
     for subkey, subdata in config.get('subscriptions', {}).items():
@@ -148,14 +150,19 @@ def parse_commit(payload, config):
                         break
 
 
-def main():
+async def main():
     print("Loading occ.yaml")
     cfg = yaml.safe_load(open('occ.yaml'))
-    print("Connecting to pyPubSub at %s" % cfg['pubsub']['url'])
-    pypubsub = asfpy.pubsub.Listener(cfg['pubsub']['url'])
-    print("Connected, listening for events :-)")
-    pypubsub.attach(lambda x: parse_commit(x, cfg), auth=(cfg['pubsub']['user'], cfg['pubsub']['pass']), raw=True)
+    print("Listening to pyPubSub stream at %s" % cfg['pubsub']['url'])
+    async for payload in asfpy.pubsub.listen(cfg['pubsub']['url'], username=cfg['pubsub']['user'], password=cfg['pubsub']['pass']):
+        await parse_commit(payload, cfg)
 
 
 if __name__ == "__main__":
-    main()
+    # Default modern async behavior (Python>=3.7)
+    if sys.version_info.minor >= 7:
+        asyncio.run(main())
+    # Python<=3.6 async fallback
+    else:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML>=5.3.1
-asfpy>=0.20
+PyYAML>=5.4.1
+asfpy>=0.45


### PR DESCRIPTION
This PR switches to the new async asfpy pubsub listener, as well as a minor update to the "whoami" process, utilizing asfpy's better mechanism for this. This PR is primarily intended to improve stability in OCC.