### PR TITLE
docker

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,21 @@
+FROM alpine:latest
+
+LABEL project="https://github.com/apache/infrastructure-occ"
+
+ARG WDIR=/usr/src/occ
+ARG CDIR=/etc/occ
+ARG GIT_OCCVER=main
+
+RUN apk --no-cache add python3 py-pip git
+
+RUN git clone -b $GIT_OCCVER https://github.com/nser77/infrastructure-occ.git $WDIR
+
+WORKDIR $WDIR
+
+RUN pip install -r requirements.txt
+
+RUN apk --no-cache del git py-pip
+
+RUN mkdir $CDIR
+
+ENTRYPOINT ["/usr/bin/python", "-u", "occ.py", "--config-file", "/etc/occ/occ.yaml"]

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -3,7 +3,7 @@
 version: '3.3'
 services:
     occ:
-        image: occ
+        build: https://github.com/nser77/infrastructure-occ.git#main:docker/build
         volumes:
             -  /etc/occ:/etc/occ
         cap_drop:

--- a/docker/compose/docker-compose.yaml
+++ b/docker/compose/docker-compose.yaml
@@ -1,0 +1,10 @@
+# skeleton 0.0.1
+
+version: '3.3'
+services:
+    occ:
+        image: occ
+        volumes:
+            -  /etc/occ:/etc/occ
+        cap_drop:
+            - ALL

--- a/occ.py
+++ b/occ.py
@@ -153,13 +153,14 @@ async def parse_commit(payload, config):
 
 def ocCli():
     parser = argparse.ArgumentParser(description='infrastructure-occ')
-    parser.add_argument('--config-file', type=str, help='YAML configuration file.')
+    parser.add_argument('--config-file', type=str, default="occ.yaml", help='YAML configuration file. Default is: occ.yaml')
     return parser.parse_args()
+
 
 async def main():
     args = ocCli()
-    print("Loading %s" % args.config_file)
     cfg = yaml.safe_load(open(args.config_file))
+    print("%s loaded." % args.config_file)
     print("Listening to pyPubSub stream at %s" % cfg['pubsub']['url'])
     async for payload in asfpy.pubsub.listen(cfg['pubsub']['url'], username=cfg['pubsub']['user'], password=cfg['pubsub']['pass']):
         await parse_commit(payload, cfg)

--- a/occ.py
+++ b/occ.py
@@ -16,6 +16,8 @@
 # limitations under the License.
 """On-Commit-Commands - a simple pubsub client that runs a command on commit activity"""
 
+from argparse import ArgumentParser
+
 import asfpy.messaging
 import asfpy.pubsub
 import asfpy.syslog
@@ -27,7 +29,6 @@ import os
 import getpass
 import asyncio
 import sys
-import argparse
 
 print = asfpy.syslog.Printer(stdout=True, identity="occ")
 
@@ -152,7 +153,7 @@ async def parse_commit(payload, config):
 
 
 def ocCli():
-    parser = argparse.ArgumentParser(description='infrastructure-occ')
+    parser = ArgumentParser(description='infrastructure-occ')
     parser.add_argument('--config-file', type=str, default="occ.yaml", help='YAML configuration file. Default is: occ.yaml')
     return parser.parse_args()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML>=5.4.1
 asfpy>=0.45
+argparse>=1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 PyYAML>=5.4.1
 asfpy>=0.45
-argparse>=1.4.0


### PR DESCRIPTION
Hi, this patch wants to add docker compatibility, hope it will be appreciated.

Two main changes were introduced:
- Created ```docker-image``` and ```docker-compose``` files
- Added ```argparse``` library

```docker-image``` and ```docker-compose``` are still downloading ```https://github.com/nser77/infrastructure-occ.git``` OCC version, but if the patch will be merged onto the main project they should use :  ```https://github.com/apache/infrastructure-occ.git```.

To test the patch simply run:

```
docker-compose -f docker-compose.yaml up
```

Where ```docker-compose``` is [nser/docker/compose/docker-compose.yaml](https://github.com/nser77/infrastructure-occ/blob/main/docker/compose/docker-compose.yaml)